### PR TITLE
Fixed server option for verbosity.

### DIFF
--- a/supriya/tools/servertools/Server.py
+++ b/supriya/tools/servertools/Server.py
@@ -388,7 +388,7 @@ class Server(SupriyaObject):
         if kwargs:
             server_options = new(server_options, **kwargs)
         options_string = server_options.as_options_string(self.port)
-        command = '{} {} -V -1'.format(scsynth_path, options_string)
+        command = '{} {} -v -1'.format(scsynth_path, options_string)
         self._server_process = subprocess.Popen(command, shell=True)
         time.sleep(0.25)
         self._is_running = True


### PR DESCRIPTION
The correct flag is `-v`, not `-V`. The latter doesn't work on Linux
with SC 3.6.6. In SC 3.7 `-V` will return the version (see
https://github.com/supercollider/supercollider/issues/1310).