### PR TITLE
Fix error in README code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Synchronize with the server::
 
 Create a synthesizer with the previously defined synthesizer definition::
 
-    >>> synth = servertools.Synth(synthdef)
+    >>> synth = supriya.Synth(synthdef)
     >>> synth
     <Synth: ???>
 


### PR DESCRIPTION
This fixes the following error in `README.rst`:
changes `synth = servertools.Synth(synthdef)` to `synth = supriya.Synth(synthdef)`

The latter statement works with the current code in `HEAD master`. The former does not.