### PR TITLE
Allow specifying boot executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,11 @@ extras_require = {
         'isort',
         'mypy',
         'pytest >= 3.6.0',
-        'pytest-helpers-namespace',
-        'pytest-timeout >= 1.2.0',
         'pytest-cov',
+        'pytest-helpers-namespace',
         'pytest-profiling',
+        'pytest-rerunfailures>=5.0',
+        'pytest-timeout >= 1.2.0',
     ],
 }
 

--- a/supriya/__init__.py
+++ b/supriya/__init__.py
@@ -3,7 +3,7 @@ import configparser  # noqa
 import pathlib  # noqa
 import pyximport  # type: ignore
 
-pyximport.install()
+pyximport.install(language_level=3)
 
 output_path = pathlib.Path(appdirs.user_cache_dir('supriya', 'supriya'))
 if not output_path.exists():

--- a/supriya/realtime/Server.py
+++ b/supriya/realtime/Server.py
@@ -1,6 +1,6 @@
 import os
+import pathlib
 import signal
-import traceback
 import atexit
 import re
 import subprocess
@@ -592,24 +592,29 @@ class Server(SupriyaObject):
 
     def boot(
         self,
+        scsynth_path=None,
         server_options=None,
         **kwargs
     ):
         import supriya.realtime
         if self.is_running:
             return self
-        from os import environ
-        scsynth_path = environ.get('SCSYNTH_PATH')
+        scsynth_path = scsynth_path or os.environ.get('SCSYNTH_PATH')
         if not scsynth_path:
             scsynth_path_candidates = uqbar.io.find_executable('scsynth')
             if not scsynth_path_candidates:
                 raise RuntimeError('Cannot find scsynth')
             scsynth_path = scsynth_path_candidates[0]
+        scsynth_path = pathlib.Path(scsynth_path).absolute()
+        if not scsynth_path.exists():
+            raise RuntimeError('{} does not exist'.format(scsynth_path))
+
         self._osc_io.boot(
             ip_address=self.ip_address,
             port=self.port,
         )
         self._setup_osc_callbacks()
+
         server_options = server_options or supriya.realtime.ServerOptions()
         assert isinstance(server_options, supriya.realtime.ServerOptions)
         if kwargs:

--- a/tests/test_realtime_Node__handle_response.py
+++ b/tests/test_realtime_Node__handle_response.py
@@ -1,9 +1,11 @@
+import pytest
 import supriya.assets.synthdefs
 import supriya.osc
 import supriya.realtime
 import uqbar.strings
 
 
+@pytest.mark.flaky(reruns=5)
 def test_01(server):
 
     group_a = supriya.realtime.Group().allocate()


### PR DESCRIPTION
Add optional `scsynth_path` keyword to `Server.boot()`, overriding `SCSYNTH_PATH` environment variable and any auto-detected `scsynth`. This allows for specific `scsynth` versions, or using `supernova`.