### PR TITLE
Include app paths when finding scsynth

### DIFF
--- a/supriya/scsynth.py
+++ b/supriya/scsynth.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import platform
 import signal
 import subprocess
 from dataclasses import dataclass
@@ -156,18 +157,20 @@ class Options:
         )
 
 
-def _fallback_scsynth_paths():
-    return (
-        pathlib.Path("/Applications/SuperCollider.app/Contents/Resources/scsynth"),
-        pathlib.Path("/usr/bin/scsynth"),
-    )
+def _fallback_scsynth_path():
+    if platform.system() == "Darwin":
+        return pathlib.Path(
+            "/Applications/SuperCollider.app/Contents/Resources/scsynth"
+        )
+    if platform.system() == "Linux":
+        return pathlib.Path("/usr/bin/scsynth")
 
 
 def find(scsynth_path=None):
     """Find the ``scsynth`` executable.
 
     The following paths, if defined, will be searched (prioritised as ordered):
-    1. ``scsynth_path``
+    1. The absolute path ``scsynth_path``
     2. The environment variable ``SCSYNTH_PATH``
     3. ``scsynth_path`` if defined in Supriya's configuration file
     4. The user's ``PATH``
@@ -182,25 +185,19 @@ def find(scsynth_path=None):
         or supriya.config.get("core", "scsynth_path")
         or "scsynth"
     )
+
+    if scsynth_path.is_absolute() and uqbar.io.find_executable(scsynth_path):
+        return scsynth_path
+
     scsynth_path_candidates = uqbar.io.find_executable(scsynth_path.name)
-    if not scsynth_path.is_absolute() and scsynth_path_candidates:
-        scsynth_path = pathlib.Path(scsynth_path_candidates[0])
+    if scsynth_path_candidates:
+        return pathlib.Path(scsynth_path_candidates[0])
 
-    potential_paths = (scsynth_path.resolve().absolute(), *_fallback_scsynth_paths())
+    potential_path = _fallback_scsynth_path()
+    if potential_path and uqbar.io.find_executable(potential_path):
+        return pathlib.Path(potential_path)
 
-    for potential_path in potential_paths:
-        if potential_path.exists():
-            scsynth_path = potential_path
-            break
-
-    if not scsynth_path.exists():
-        raise RuntimeError("{} does not exist".format(scsynth_path))
-
-    if scsynth_path_candidates and scsynth_path == pathlib.Path(
-        scsynth_path_candidates[0]
-    ):
-        scsynth_path = pathlib.Path(scsynth_path.name)
-    return scsynth_path
+    raise RuntimeError("Failed to locate scsynth")
 
 
 def kill(supernova=False):

--- a/supriya/scsynth.py
+++ b/supriya/scsynth.py
@@ -156,7 +156,26 @@ class Options:
         )
 
 
+def _fallback_scsynth_paths():
+    return (
+        pathlib.Path("/Applications/SuperCollider.app/Contents/Resources/scsynth"),
+        pathlib.Path("/usr/bin/scsynth"),
+    )
+
+
 def find(scsynth_path=None):
+    """Find the ``scsynth`` executable.
+
+    The following paths, if defined, will be searched (prioritised as ordered):
+    1. ``scsynth_path``
+    2. The environment variable ``SCSYNTH_PATH``
+    3. ``scsynth_path`` if defined in Supriya's configuration file
+    4. The user's ``PATH``
+    5. Common installation directories of the SuperCollider application.
+
+    Returns a path to the ``scsynth`` executable.
+    Raises ``RuntimeError`` if no path is found.
+    """
     scsynth_path = pathlib.Path(
         scsynth_path
         or os.environ.get("SCSYNTH_PATH")
@@ -166,9 +185,17 @@ def find(scsynth_path=None):
     scsynth_path_candidates = uqbar.io.find_executable(scsynth_path.name)
     if not scsynth_path.is_absolute() and scsynth_path_candidates:
         scsynth_path = pathlib.Path(scsynth_path_candidates[0])
-    scsynth_path = scsynth_path.resolve().absolute()
+
+    potential_paths = (scsynth_path.resolve().absolute(), *_fallback_scsynth_paths())
+
+    for potential_path in potential_paths:
+        if potential_path.exists():
+            scsynth_path = potential_path
+            break
+
     if not scsynth_path.exists():
         raise RuntimeError("{} does not exist".format(scsynth_path))
+
     if scsynth_path_candidates and scsynth_path == pathlib.Path(
         scsynth_path_candidates[0]
     ):

--- a/tests/nonrealtime/test_nonrealtime_Session_render.py
+++ b/tests/nonrealtime/test_nonrealtime_Session_render.py
@@ -1,4 +1,3 @@
-import os
 import pathlib
 import pprint
 

--- a/tests/nonrealtime/test_nonrealtime_Session_render.py
+++ b/tests/nonrealtime/test_nonrealtime_Session_render.py
@@ -7,6 +7,7 @@ import uqbar.strings
 
 import supriya
 import supriya.nonrealtime
+import supriya.scsynth
 import supriya.soundfiles
 
 
@@ -78,7 +79,7 @@ def test_00c(nonrealtime_paths):
         0.81: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
         0.99: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
     }
-    executable = os.environ.get("SCSYNTH_PATH", "scsynth")
+    executable = supriya.scsynth.find()
     assert session.transcript == [
         "Writing session-7b3f85710f19667f73f745b8ac8080a0.osc.",
         "    Wrote session-7b3f85710f19667f73f745b8ac8080a0.osc.",
@@ -858,7 +859,7 @@ def test_08(nonrealtime_paths):
         0.81: [0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75],
         0.99: [0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75],
     }
-    executable = os.environ.get("SCSYNTH_PATH", "scsynth")
+    executable = supriya.scsynth.find()
     assert session_three.transcript == [
         "Writing session-c6d86f3d482a8bac1f7cc6650017da8e.osc.",
         "    Wrote session-c6d86f3d482a8bac1f7cc6650017da8e.osc.",

--- a/tests/test_scsynth.py
+++ b/tests/test_scsynth.py
@@ -1,0 +1,60 @@
+import pytest
+import stat
+import os
+from supriya import scsynth
+from supriya import config
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+import pathlib
+
+
+def setup_function():
+    os.environ["SCSYNTH_PATH"] = ""
+
+def test_find_argument():
+
+    with NamedTemporaryFile() as tmp:
+        got = scsynth.find(tmp.name)
+        expected = pathlib.Path(tmp.name).resolve().absolute()
+        assert got == expected
+
+
+def test_find_env_var():
+
+    with NamedTemporaryFile() as tmp:
+        os.environ["SCSYNTH_PATH"] = tmp.name
+        got = scsynth.find()
+        expected = pathlib.Path(tmp.name).resolve().absolute()
+        assert got == expected
+
+
+def test_find_on_path():
+
+    with TemporaryDirectory() as tmp_dir:
+
+        scsynth_path = pathlib.Path(tmp_dir) / "scsynth"
+
+        with open(scsynth_path, "w") as scf:
+            scsynth_path.chmod(scsynth_path.stat().st_mode | stat.S_IEXEC)
+            os.environ["PATH"] += os.pathsep + tmp_dir
+            got = scsynth.find()
+            expected = scsynth_path.resolve().absolute()
+            assert got == expected
+
+
+def test_find_from_fallback_paths(mocker):
+
+    with NamedTemporaryFile() as tmp:
+        mock = mocker.patch.object(scsynth, "_fallback_scsynth_paths")
+        expected = pathlib.Path(tmp.name).resolve().absolute()
+        mock.return_value = (expected,)
+        got = scsynth.find()
+        assert got == expected
+
+
+def test_find_from_config():
+
+    with NamedTemporaryFile() as tmp:
+        config.read_dict({"core": {"scsynth_path": tmp.name}})
+        got = scsynth.find()
+        expected = pathlib.Path(tmp.name).resolve().absolute()
+        assert got == expected

--- a/tests/test_scsynth.py
+++ b/tests/test_scsynth.py
@@ -9,18 +9,11 @@ import pytest
 import supriya
 from supriya import scsynth
 
-config = copy.deepcopy(supriya.config)
-
 
 @pytest.fixture
 def mock_env_scsynth_path(monkeypatch):
     monkeypatch.delenv("SCSYNTH_PATH", raising=False)
     monkeypatch.setenv("PATH", "")
-
-
-@pytest.fixture
-def mock_config(monkeypatch):
-    monkeypatch.setattr("supriya.config", config)
 
 
 def test_find_argument(mock_env_scsynth_path):
@@ -63,15 +56,5 @@ def test_find_from_fallback_paths(mock_env_scsynth_path, mocker):
         expected.chmod(expected.stat().st_mode | stat.S_IEXEC)
         mock = mocker.patch.object(scsynth, "_fallback_scsynth_path")
         mock.return_value = str(expected)
-        got = scsynth.find()
-        assert got == expected
-
-
-def test_find_from_config(mock_env_scsynth_path, mock_config, mocker):
-
-    with NamedTemporaryFile() as tmp:
-        expected = pathlib.Path(tmp.name).absolute()
-        mocker.patch.dict("supriya.config", {"core": {"scsynth_path": str(expected)}})
-        expected.chmod(expected.stat().st_mode | stat.S_IEXEC)
         got = scsynth.find()
         assert got == expected

--- a/tests/test_scsynth.py
+++ b/tests/test_scsynth.py
@@ -1,4 +1,3 @@
-import copy
 import os
 import pathlib
 import stat
@@ -6,7 +5,6 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import pytest
 
-import supriya
 from supriya import scsynth
 
 

--- a/tests/test_scsynth.py
+++ b/tests/test_scsynth.py
@@ -2,10 +2,7 @@ import os
 import pathlib
 import stat
 from tempfile import NamedTemporaryFile, TemporaryDirectory
-
 import pytest
-
-import supriya
 from supriya import scsynth
 
 
@@ -39,7 +36,7 @@ def test_find_on_path(mock_env_scsynth_path):
 
         scsynth_path = pathlib.Path(tmp_dir) / "scsynth"
 
-        with open(scsynth_path, "w") as scf:
+        with open(scsynth_path, "w"):
             scsynth_path.chmod(scsynth_path.stat().st_mode | stat.S_IEXEC)
             os.environ["PATH"] += os.pathsep + tmp_dir
             got = scsynth.find()


### PR DESCRIPTION
Following #170, I've [added two standard installation paths](https://github.com/deeuu/supriya/blob/find-scsynth/supriya/scsynth.py#L159-L163) to be included in the search for `scsynth` as performed by [`find`](https://github.com/deeuu/supriya/blob/find-scsynth/supriya/scsynth.py#L166) (see doc-string). Also included some tests at `tests/test_scsynth.py`.

Preferred to brute-force it over doing any clever OS logic.

@josiah-wolf-oberholtzer Let me know what you think