### PR TITLE
Allocate a new default group for supernova client with large ID no.

### DIFF
--- a/supriya/realtime/servers.py
+++ b/supriya/realtime/servers.py
@@ -1051,7 +1051,15 @@ class Server(BaseServer):
         if self.client_id > 0:
             self._setup_system_synthdefs(local_only=True)
             self._rehydrate()
-        self._default_group = self._nodes[self.client_id + 1]
+        # Supernova ignores max_logins value, so clients with large ID
+        # need to allocate their own default group here
+        if self.client_id >= len(self._nodes) - 2:
+            self._default_group = Group().allocate(
+                target_node=self._nodes[0],
+                add_action=supriya.enums.AddAction.ADD_TO_TAIL,
+            )
+        else:
+            self._default_group = self._nodes[self.client_id + 1]
         return self
 
     def disconnect(self) -> "Server":


### PR DESCRIPTION
I would like to connect and disconnect to a running supernova server.  Because supernova ignores maxLogins value, nnce my `clientID` is larger than `1`, supriya throws an error trying to access another default group in Server._nodes.

My solution is to allocate a new defalut group for each client with ID larger than `len(Server._nodes) -2`.

Unfortunately, the server assigns new group ID that are large numbers in random order, e.g.:

```
NODE TREE 0 group
    1 group
    1000 group
    67109864 group
    134218728 group
    201327592 group
    268436456 group
    335545320 group
    402654184 group
```

Any ideas why?