### PR TITLE
Increase waiting time for test_RealtimeProvider

### DIFF
--- a/tests/providers/test_RealtimeProvider.py
+++ b/tests/providers/test_RealtimeProvider.py
@@ -160,7 +160,7 @@ def test_RealtimeProvider_add_group_2(server):
         [None, [["/g_new", 1000, 0, 1]]],
         [seconds + 0.01 + provider.latency, [["/g_new", 1001, 0, 1000]]],
     ]
-    time.sleep(0.1)
+    time.sleep(0.2)
     assert str(server.query()) == normalize(
         """
         NODE TREE 0 group
@@ -250,7 +250,7 @@ def test_RealtimeProvider_add_synth_2(server):
             [["/s_new", "default", 1001, 0, 1000, "amplitude", 0.5, "frequency", 666]],
         ],
     ]
-    time.sleep(0.1)
+    time.sleep(0.2)
     assert str(server.query()) == normalize(
         """
         NODE TREE 0 group


### PR DESCRIPTION
As of now, supriya passes all test on my machine, except two in `tests/providers/test_RealtimeProvider.py`.

My setup is JACK on Linux, with 48000 sample rate and block size 512.

The two tests *always fail* on my machine if the waiting time 0.1s, and they *always pass* if waiting time is 0.2s.
This makeshift solution works well for me.