### PR TITLE
Add parallel=False flag to Group()

### DIFF
--- a/supriya/providers.py
+++ b/supriya/providers.py
@@ -764,7 +764,6 @@ class NonrealtimeProvider(Provider):
     ) -> GroupProxy:
         if not self.moment:
             raise ValueError("No current moment")
-        # TODO: implement (dummy) parallel flag for nonrealtime methods
         identifier = self._resolve_target_node(target_node).add_group(
             add_action=add_action
         )

--- a/supriya/providers.py
+++ b/supriya/providers.py
@@ -272,7 +272,6 @@ class GroupProxy(NodeProxy):
         request_method = commands.GroupNewRequest
         if self.parallel:
             request_method = commands.ParallelGroupNewRequest
-
         return request_method(
             items=[
                 request_method.Item(

--- a/supriya/providers.py
+++ b/supriya/providers.py
@@ -263,11 +263,19 @@ class NodeProxy(Proxy):
 class GroupProxy(NodeProxy):
     identifier: Union["supriya.nonrealtime.Node", int]
     provider: "Provider"
+    parallel: bool = False
 
-    def as_add_request(self, add_action, target_node) -> commands.GroupNewRequest:
-        return commands.GroupNewRequest(
+    def as_add_request(
+        self, add_action, target_node
+    ) -> Union[commands.GroupNewRequest, commands.ParallelGroupNewRequest]:
+
+        request_method = commands.GroupNewRequest
+        if self.parallel:
+            request_method = commands.ParallelGroupNewRequest
+
+        return request_method(
             items=[
-                commands.GroupNewRequest.Item(
+                request_method.Item(
                     node_id=int(self.identifier),
                     add_action=add_action,
                     target_node_id=int(target_node),
@@ -543,6 +551,7 @@ class Provider(metaclass=abc.ABCMeta):
         target_node=None,
         add_action=AddAction.ADD_TO_HEAD,
         name: Optional[str] = None,
+        parallel: bool = False,
     ) -> GroupProxy:
         raise NotImplementedError
 
@@ -751,13 +760,15 @@ class NonrealtimeProvider(Provider):
         target_node=None,
         add_action=AddAction.ADD_TO_HEAD,
         name: Optional[str] = None,
+        parallel: bool = False,
     ) -> GroupProxy:
         if not self.moment:
             raise ValueError("No current moment")
+        # TODO: implement (dummy) parallel flag for nonrealtime methods
         identifier = self._resolve_target_node(target_node).add_group(
             add_action=add_action
         )
-        proxy = GroupProxy(identifier=identifier, provider=self)
+        proxy = GroupProxy(identifier=identifier, provider=self, parallel=parallel)
         return proxy
 
     def add_synth(
@@ -938,12 +949,13 @@ class RealtimeProvider(Provider):
         target_node=None,
         add_action=AddAction.ADD_TO_HEAD,
         name: Optional[str] = None,
+        parallel: bool = False,
     ) -> GroupProxy:
         if not self.moment:
             raise ValueError("No current moment")
         target_node = self._resolve_target_node(target_node)
         identifier = self._server.node_id_allocator.allocate_node_id(1)
-        proxy = GroupProxy(identifier=identifier, provider=self)
+        proxy = GroupProxy(identifier=identifier, provider=self, parallel=parallel)
         self.moment.node_additions.append((proxy, add_action, target_node))
         if name:
             self._annotation_map[identifier] = name

--- a/supriya/realtime/nodes.py
+++ b/supriya/realtime/nodes.py
@@ -673,10 +673,9 @@ class Group(Node, UniqueTreeList):
                 requests.append(request)
             else:
                 if isinstance(node, Group):
+                    request_method = supriya.commands.GroupNewRequest
                     if node.parallel:
                         request_method = supriya.commands.ParallelGroupNewRequest
-                    else:
-                        request_method = supriya.commands.GroupNewRequest
                     request = request_method(
                         items=[
                             request_method.Item(

--- a/supriya/realtime/servers.py
+++ b/supriya/realtime/servers.py
@@ -964,7 +964,9 @@ class Server(BaseServer):
         bus_group.allocate(server=self)
         return bus_group
 
-    def add_group(self, add_action: Optional[AddActionLike] = None) -> Group:
+    def add_group(
+        self, add_action: Optional[AddActionLike] = None, parallel: bool = False
+    ) -> Group:
         """
         Add a group relative to the default group via ``add_action``.
 
@@ -986,7 +988,7 @@ class Server(BaseServer):
         """
         if self.default_group is None:
             raise ServerOffline
-        return self.default_group.add_group(add_action=add_action)
+        return self.default_group.add_group(add_action=add_action, parallel=parallel)
 
     def add_synth(
         self, synthdef=None, add_action: Optional[AddActionLike] = None, **kwargs

--- a/tests/providers/test_RealtimeProvider.py
+++ b/tests/providers/test_RealtimeProvider.py
@@ -5,6 +5,7 @@ from uqbar.strings import normalize
 
 from supriya.assets.synthdefs import default
 from supriya.enums import AddAction, CalculationRate
+from supriya.osc.messages import OscBundle, OscMessage
 from supriya.providers import (
     BufferProxy,
     BusGroupProxy,
@@ -564,3 +565,13 @@ def test_RealtimeProvider_set_node_error(server):
         group_proxy["foo"] = 23
     with pytest.raises(ValueError):
         synth_proxy["foo"] = 23
+
+
+def test_RealtimeProvider_add_group_parallel(server):
+    provider = Provider.from_context(server)
+    with server.osc_protocol.capture() as transcript:
+        with provider.at(None):
+            provider.add_group(parallel=True)
+    assert [(_.label, _.message) for _ in transcript] == [
+        ("S", OscBundle(contents=(OscMessage("/p_new", 1000, 0, 1),)))
+    ]


### PR DESCRIPTION
...to allow allocation of parallel groups on supernova.

Ref.: #https://github.com/gitmarek/supriya/commit/cef6ef88d10d5571a038a7bdc1eb2e2ad3b29f78#r87738788

Locally, all tests passed, so it looks like I didn't break anything. Before squashing anything, I'm going to test it manually and wait for supernova to be deployed on GHA to try to write some unit tests too...