### PR TITLE
Check for NTP timestamp oveflow

### DIFF
--- a/supriya/osc/messages.py
+++ b/supriya/osc/messages.py
@@ -362,7 +362,8 @@ class OscBundle(SupriyaValueObject):
             return IMMEDIATELY
         if realtime:
             seconds = seconds + NTP_DELTA
-            return struct.pack(">Q", int(seconds * SECONDS_TO_NTP_TIMESTAMP))
+        if seconds >= 4294967296:  # 2**32
+            seconds = seconds % 4294967296
         return struct.pack(">Q", int(seconds * SECONDS_TO_NTP_TIMESTAMP))
 
     ### PUBLIC METHODS ###

--- a/tests/osc/test_osc_OscMessage.py
+++ b/tests/osc/test_osc_OscMessage.py
@@ -51,3 +51,8 @@ def test():
     ), ['a', 'b', ['c', 'd']])
     """
     )
+
+
+def test_new_ntp_era():
+    datagram = supriya.osc.OscBundle._encode_date(seconds=2085978496)
+    assert datagram.hex() == "0000000000000000"

--- a/tests/osc/test_osc_OscMessage.py
+++ b/tests/osc/test_osc_OscMessage.py
@@ -54,5 +54,9 @@ def test():
 
 
 def test_new_ntp_era():
-    datagram = supriya.osc.OscBundle._encode_date(seconds=2085978496)
-    assert datagram.hex() == "0000000000000000"
+    """
+    Check for NTP timestamp overflow.
+    """
+    seconds = 2**32 - supriya.osc.messages.NTP_DELTA + 1
+    datagram = supriya.osc.OscBundle._encode_date(seconds=seconds)
+    assert datagram.hex() == "0000000100000000"


### PR DESCRIPTION
Prepare for 8 Feb 2036.

Ref.: https://github.com/gitmarek/supriya/pull/14
See also: https://www.eecis.udel.edu/~mills/y2k.html