### PR TITLE
Pass BlockAllocator.allocate_at() assertion

### DIFF
--- a/supriya/realtime/allocators.py
+++ b/supriya/realtime/allocators.py
@@ -163,6 +163,8 @@ class BlockAllocator(SupriyaObject):
             blocks = sorted(
                 set(cursor.start_intervals) or set(cursor.overlap_intervals)
             )
+            if len(blocks) == 0:
+                return None
             assert len(blocks) == 1
             used_block = blocks[0]
             self._used_heap.remove(used_block)

--- a/supriya/realtime/allocators.py
+++ b/supriya/realtime/allocators.py
@@ -137,6 +137,8 @@ class BlockAllocator(SupriyaObject):
                 stop_cursor.overlap_intervals + stop_cursor.stop_intervals
             )
             if starting_blocks == stop_blocks:
+                if len(starting_blocks) == 0:
+                    return None
                 assert len(starting_blocks) == 1
                 free_block = starting_blocks[0]
                 used_block = supriya.realtime.Block(

--- a/tests/realtime/test_BlockAllocator.py
+++ b/tests/realtime/test_BlockAllocator.py
@@ -30,6 +30,14 @@ def test_allocate():
 
 def test_allocate_block_within_block():
     allocator = supriya.realtime.BlockAllocator()
-    assert allocator.allocate(1) == 0
+    assert allocator.allocate_at(0, 3) == 0
     assert allocator.allocate_at(0, 2) is None
-    assert allocator.allocate_at(0, 1) is None
+    assert allocator.allocate_at(1, 2) is None
+    assert allocator.allocate_at(2, 2) is None
+    assert allocator.allocate_at(6, 3) == 6
+    assert allocator.allocate_at(5, 2) is None
+    assert allocator.allocate_at(2, 5) is None
+    assert allocator.allocate_at(0, 9) is None
+    assert allocator.allocate_at(3, 3) == 3
+
+    assert allocator.free(99) is None

--- a/tests/realtime/test_BlockAllocator.py
+++ b/tests/realtime/test_BlockAllocator.py
@@ -26,3 +26,10 @@ def test_allocate():
 
     assert allocator.allocate(1) == 4
     assert allocator.allocate(1) == 5
+
+
+def test_allocate_block_within_block():
+    allocator = supriya.realtime.BlockAllocator()
+    assert allocator.allocate(1) == 0
+    assert allocator.allocate_at(0, 2) is None
+    assert allocator.allocate_at(0, 1) is None


### PR DESCRIPTION
When trying to allocate a block within an already allocated block with `BlockAllocator()` (Hypothesis wants to do it all the time...) Supriya fails on its internal assertion. See 4b75572e5393f144de93534799bfe769b214a615 for how to trigger this.

A solution could be to test for empty `starting_blocks` in `BlockAllocator.allocate_at()`.