### PR TITLE
Allow passing tuples of floats to `def add_synth`

### DIFF
--- a/supriya/assets/synthdefs/__init__.py
+++ b/supriya/assets/synthdefs/__init__.py
@@ -5,4 +5,4 @@ from .multiband_compressor import multiband_compressor  # noqa
 from .simple_sine import simple_sine  # noqa
 from .sweep_filter import sweep_filter  # noqa
 from .system_synthdefs import *  # noqa
-from .test import test  # noqa
+from .test import test, test_two_voice  # noqa

--- a/supriya/assets/synthdefs/test.py
+++ b/supriya/assets/synthdefs/test.py
@@ -15,6 +15,19 @@ def _build_test_synthdef():
     return synthdef
 
 
-test = _build_test_synthdef()
+def _build_test_two_voice_synthdef():
+    with SynthDefBuilder(
+        frequencies=(220, 440),
+        amplitude=Parameter(value=1.0, parameter_rate=ParameterRate.AUDIO),
+    ) as builder:
+        sin_osc = SinOsc.ar(frequency=builder["frequencies"])
+        enveloped_sin = sin_osc * builder["amplitude"]
+        Out.ar(bus=0, source=enveloped_sin)
+    synthdef = builder.build(name="test_two_voice")
+    return synthdef
 
-__all__ = ("test",)
+
+test = _build_test_synthdef()
+test_two_voice = _build_test_two_voice_synthdef()
+
+__all__ = ("test", "test_two_voice")

--- a/supriya/contexts/core.py
+++ b/supriya/contexts/core.py
@@ -598,7 +598,7 @@ class Context(metaclass=abc.ABCMeta):
                 raise ValueError(add_action_)
         target_node_id = self._resolve_node(target_node)
         synthdef_kwargs: Dict[
-            Union[int, str], Union[SupportsFloat, str, tuple[float, ...]]
+            Union[int, str], Union[SupportsFloat, str, Tuple[float, ...]]
         ] = {}
         for _, parameter in synthdef.indexed_parameters:
             if parameter.name not in settings:

--- a/supriya/contexts/core.py
+++ b/supriya/contexts/core.py
@@ -612,6 +612,8 @@ class Context(metaclass=abc.ABCMeta):
                 synthdef_kwargs[parameter.name] = value.map_symbol()
             elif isinstance(value, str):
                 synthdef_kwargs[parameter.name] = value
+            elif isinstance(value, tuple):
+                synthdef_kwargs[parameter.name] = tuple((float(v) for v in value))
             else:
                 synthdef_kwargs[parameter.name] = float(value)
         id_ = self._allocate_id(Node, permanent=permanent)

--- a/supriya/contexts/core.py
+++ b/supriya/contexts/core.py
@@ -597,7 +597,9 @@ class Context(metaclass=abc.ABCMeta):
             if add_action_ not in target_node._valid_add_actions:
                 raise ValueError(add_action_)
         target_node_id = self._resolve_node(target_node)
-        synthdef_kwargs: Dict[Union[int, str], Union[SupportsFloat, str]] = {}
+        synthdef_kwargs: Dict[
+            Union[int, str], Union[SupportsFloat, str, tuple[float, ...]]
+        ] = {}
         for _, parameter in synthdef.indexed_parameters:
             if parameter.name not in settings:
                 continue

--- a/supriya/contexts/requests.py
+++ b/supriya/contexts/requests.py
@@ -1319,7 +1319,12 @@ class NewSynth(Request):
         ]
         for key, value in sorted((self.controls or {}).items()):
             contents.append(key if isinstance(key, str) else int(key))
-            contents.append(value if isinstance(value, str) else float(value))
+            if isinstance(value, str):
+                contents.append(value)
+            elif isinstance(value, tuple):
+                contents.append(tuple((float(v) for v in value)))
+            else:
+                contents.append(float(value))
         return OscMessage(RequestName.SYNTH_NEW, *contents)
 
 

--- a/supriya/contexts/requests.py
+++ b/supriya/contexts/requests.py
@@ -1306,10 +1306,12 @@ class NewSynth(Request):
     synth_id: SupportsInt
     add_action: AddActionLike
     target_node_id: SupportsInt
-    controls: Optional[Dict[Union[int, str], Union[SupportsFloat, str]]] = None
+    controls: Optional[
+        Dict[Union[int, str], Union[SupportsFloat, str, tuple[float, ...]]]
+    ] = None
 
     def to_osc(self) -> OscMessage:
-        contents: List[Union[float, str]] = [
+        contents: List[Union[float, str, tuple[float, ...]]] = [
             self.synthdef.actual_name
             if isinstance(self.synthdef, SynthDef)
             else self.synthdef,

--- a/supriya/contexts/requests.py
+++ b/supriya/contexts/requests.py
@@ -1307,11 +1307,11 @@ class NewSynth(Request):
     add_action: AddActionLike
     target_node_id: SupportsInt
     controls: Optional[
-        Dict[Union[int, str], Union[SupportsFloat, str, tuple[float, ...]]]
+        Dict[Union[int, str], Union[SupportsFloat, str, Tuple[float, ...]]]
     ] = None
 
     def to_osc(self) -> OscMessage:
-        contents: List[Union[float, str, tuple[float, ...]]] = [
+        contents: List[Union[float, str, Tuple[float, ...]]] = [
             self.synthdef.actual_name
             if isinstance(self.synthdef, SynthDef)
             else self.synthdef,

--- a/tests/contexts/test_Score_nodes.py
+++ b/tests/contexts/test_Score_nodes.py
@@ -1,6 +1,7 @@
 import pytest
 
 from supriya import default
+from supriya.assets.synthdefs import test_two_voice
 from supriya.contexts.nonrealtime import Score
 from supriya.osc import OscBundle, OscMessage
 from supriya.synthdefs import SynthDefCompiler
@@ -57,6 +58,7 @@ def test_add_synth(context):
         bus_c = context.add_bus("CONTROL")
         synth = context.add_synth(default)
         context.add_synth(default, frequency=bus_a, amplitude="c0", pan=0.25, out=0)
+        context.add_synth(test_two_voice, frequencies=(123, 456))
     with context.at(1.23):
         context.add_synth(default, add_action="ADD_AFTER", target_node=synth)
         context.add_synth(default, frequency=bus_c, amplitude="a16", pan=0.25, out=0)
@@ -78,16 +80,25 @@ def test_add_synth(context):
                     "pan",
                     0.25,
                 ),
+                OscMessage(
+                    "/s_new",
+                    "test_two_voice",
+                    1002,
+                    0,
+                    0,
+                    "frequencies",
+                    (123.0, 456.0),
+                ),
             ),
             timestamp=0.0,
         ),
         OscBundle(
             contents=(
-                OscMessage("/s_new", "default", 1002, 3, 1000),
+                OscMessage("/s_new", "default", 1003, 3, 1000),
                 OscMessage(
                     "/s_new",
                     "default",
-                    1003,
+                    1004,
                     0,
                     0,
                     "amplitude",

--- a/tests/contexts/test_Server_nodes.py
+++ b/tests/contexts/test_Server_nodes.py
@@ -6,6 +6,7 @@ import pytest_asyncio
 from uqbar.strings import normalize
 
 from supriya import default
+from supriya.assets.synthdefs import test_two_voice
 from supriya.contexts.realtime import AsyncServer, Server
 from supriya.contexts.responses import NodeInfo
 from supriya.enums import NodeAction
@@ -158,6 +159,7 @@ async def test_add_synth(context):
         bus_c = context.add_bus("CONTROL")
         synth = context.add_synth(default)
         context.add_synth(default, frequency=bus_a, amplitude="c0", pan=0.25, out=0)
+        context.add_synth(test_two_voice, frequencies=(123, 456))
         with context.at(1.23):
             context.add_synth(default, add_action="ADD_AFTER", target_node=synth)
             context.add_synth(
@@ -178,13 +180,22 @@ async def test_add_synth(context):
             "pan",
             0.25,
         ),
+        OscMessage(
+            "/s_new",
+            "test_two_voice",
+            1002,
+            0,
+            1,
+            "frequencies",
+            (123.0, 456.0),
+        ),
         OscBundle(
             contents=(
-                OscMessage("/s_new", "default", 1002, 3, 1000),
+                OscMessage("/s_new", "default", 1003, 3, 1000),
                 OscMessage(
                     "/s_new",
                     "default",
-                    1003,
+                    1004,
                     0,
                     1,
                     "amplitude",


### PR DESCRIPTION
This enables passing tuples of floats to `Group.add_synth`. For example:
```
@synthdef()
def test_synth(freq=(220, 440)):
    sig = SinOsc.ar(frequency=freq) * 0.5
    sig = Mix.new(sig)
    Out.ar(bus=0, source=[sig, sig])

_ = server.add_synthdefs(test_synth)
server.sync()

group.add_synth(test_synth, freq=(220.0, 330))
```